### PR TITLE
Add Airia review responder demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# App-Review-Responder
+# App Review Responder
+
+Demo application that fetches mobile app store reviews, classifies them, retrieves matching FAQ answers with **LlamaIndex**, and drafts empathetic responses through an Airia-style pipeline. A Streamlit dashboard ties everything together for hackathon-friendly demos.
+
+## Features
+
+- **Bright Data Web Scraper** stub ready to accept real credentials for fetching Google Play or App Store reviews.
+- **FAQ knowledge base** (JSON) containing curated responses for common categories (bugs, performance, features, praise, billing, account access).
+- **Retrieval layer** built with LlamaIndex and a keyword fallback for environments without the dependency installed.
+- **Airia orchestration pipeline** that classifies reviews, retrieves knowledge, and generates personalized replies.
+- **Streamlit UI** showing raw reviews and generated responses side-by-side with a "Run pipeline" button.
+- **HoneyHive mock evaluator** returning deterministic tone/helpfulness scores for demo purposes.
+
+## Getting started
+
+1. (Optional) Install dependencies into a virtual environment:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+   > LlamaIndex is optional at runtime. When it is unavailable the retriever falls back to keyword matching, so the demo still runs.
+
+2. Launch the Streamlit interface:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+3. Provide an app identifier (package name or bundle ID), choose the store, and optionally paste a Bright Data API token. Without a token the app uses deterministic sample reviews so you can test the flow offline.
+
+4. Click **Fetch reviews** to populate the left column and **Run pipeline** to see Airia-generated responses on the right.
+
+## Airia pipeline YAML
+
+The repo contains [`airia_pipeline.yaml`](./airia_pipeline.yaml), which mirrors the Python orchestration. Upload it to Airia to execute the same classification → retrieval → response → scoring flow in production.
+
+## Extending the demo
+
+- Replace the Bright Data stub with a real dataset ID once you have credentials.
+- Swap the keyword fallback with Redis A2A embeddings by implementing a new retriever in `retrieval.py`.
+- Connect HoneyHive's API in `honeyhive.py` to replace the mock evaluator.
+
+Happy hacking! 🚀

--- a/airia_pipeline.yaml
+++ b/airia_pipeline.yaml
@@ -1,0 +1,50 @@
+version: "1.0"
+name: App Review Responder
+summary: |
+  Pipeline that classifies an incoming review, retrieves the most relevant FAQ
+  answer via LlamaIndex, and drafts a personalized response.
+
+inputs:
+  review:
+    type: object
+    description: Review payload containing at least `text`, `author`, and `rating` fields.
+
+steps:
+  - id: classify_review
+    description: Determine whether the review is a bug, feature request, praise, or complaint.
+    inputs:
+      review_text: "{{ inputs.review.text }}"
+    outputs:
+      category: "{{ python('pipeline.classify_review', review_text=inputs.review.text) }}"
+
+  - id: retrieve_faq
+    description: Query the FAQ knowledge base with LlamaIndex using the review text.
+    inputs:
+      review_text: "{{ inputs.review.text }}"
+      category: "{{ steps.classify_review.outputs.category }}"
+    outputs:
+      faq_entry: "{{ python('retrieval.FAQRetriever().retrieve', query=inputs.review.text, category=steps.classify_review.outputs.category) }}"
+
+  - id: generate_response
+    description: Blend the FAQ answer with contextual reasoning to craft a friendly response.
+    inputs:
+      review: "{{ inputs.review }}"
+      category: "{{ steps.classify_review.outputs.category }}"
+      faq_entry: "{{ steps.retrieve_faq.outputs.faq_entry }}"
+    outputs:
+      response: "{{ python('pipeline.generate_response', review=inputs.review, category=steps.classify_review.outputs.category, faq_entry=steps.retrieve_faq.outputs.faq_entry) }}"
+
+  - id: honeyhive_scoring
+    optional: true
+    description: Call HoneyHive (mock) to score tone and helpfulness.
+    inputs:
+      review_text: "{{ inputs.review.text }}"
+      response_text: "{{ steps.generate_response.outputs.response }}"
+    outputs:
+      honeyhive_score: "{{ python('honeyhive.HoneyHiveEvaluator().score', review_text=inputs.review.text, response_text=steps.generate_response.outputs.response) }}"
+
+outputs:
+  category: "{{ steps.classify_review.outputs.category }}"
+  faq_entry: "{{ steps.retrieve_faq.outputs.faq_entry }}"
+  response: "{{ steps.generate_response.outputs.response }}"
+  honeyhive_score: "{{ steps.honeyhive_scoring.outputs.honeyhive_score }}"

--- a/app.py
+++ b/app.py
@@ -1,0 +1,102 @@
+"""Streamlit UI for the App Review Responder demo."""
+from __future__ import annotations
+
+from typing import List, Dict
+
+import streamlit as st
+
+from bright_data import fetch_reviews_from_bright_data
+from faq_loader import load_faq_entries
+from pipeline import AiriaPipeline, ReviewResult
+from retrieval import LLAMA_AVAILABLE
+
+st.set_page_config(page_title="App Review Responder", layout="wide")
+st.title("📱 App Review Responder")
+st.caption(
+    "Fetch store reviews via Bright Data, ground them in an FAQ knowledge base, and respond with an Airia pipeline."
+)
+
+
+if "reviews" not in st.session_state:
+    st.session_state["reviews"] = []
+if "results" not in st.session_state:
+    st.session_state["results"] = []
+
+with st.sidebar:
+    st.header("Configuration")
+    app_id = st.text_input("App ID or Bundle ID", value="com.demo.app")
+    store = st.selectbox("Store", options=["google", "apple"], index=0)
+    max_reviews = st.slider("Max reviews", min_value=1, max_value=10, value=4)
+    api_token = st.text_input("Bright Data API token", type="password")
+    run_honeyhive = st.checkbox("Run HoneyHive evaluation", value=True)
+    st.markdown(
+        "**LlamaIndex**: {}".format("✅ available" if LLAMA_AVAILABLE else "⚠️ using keyword fallback")
+    )
+    st.markdown(
+        "The FAQ base currently contains **{}** entries.".format(len(load_faq_entries()))
+    )
+
+col_fetch, col_run = st.columns(2)
+with col_fetch:
+    if st.button("Fetch reviews", key="fetch_reviews"):
+        st.session_state["reviews"] = fetch_reviews_from_bright_data(
+            app_id=app_id,
+            store=store,
+            max_reviews=max_reviews,
+            api_token=api_token or None,
+        )
+        st.session_state["results"] = []
+        st.success(f"Loaded {len(st.session_state['reviews'])} reviews.")
+
+with col_run:
+    if st.button("Run pipeline", key="run_pipeline", type="primary"):
+        pipeline = AiriaPipeline(enable_honeyhive=run_honeyhive)
+        st.session_state["results"] = [pipeline.run(review) for review in st.session_state["reviews"]]
+        if st.session_state["results"]:
+            st.success("Pipeline generated responses.")
+        else:
+            st.info("No reviews available. Fetch reviews first.")
+
+reviews: List[Dict[str, str]] = st.session_state.get("reviews", [])
+results: List[ReviewResult] = st.session_state.get("results", [])
+
+left, right = st.columns(2)
+
+with left:
+    st.subheader("Raw reviews")
+    if not reviews:
+        st.info("Fetch reviews to populate this column.")
+    else:
+        for idx, review in enumerate(reviews, start=1):
+            st.markdown(f"**Review {idx}** — {review.get('author', 'Anonymous')} ({review.get('rating', 'N/A')}★)")
+            st.write(review.get("text", ""))
+            meta = {key: review[key] for key in ["id", "date", "store"] if key in review}
+            if meta:
+                st.caption(str(meta))
+            st.markdown("---")
+
+with right:
+    st.subheader("Airia responses")
+    if not results:
+        st.info("Run the pipeline to generate responses.")
+    else:
+        for idx, result in enumerate(results, start=1):
+            st.markdown(f"**Response {idx}** — classified as `{result.category}`")
+            st.write(result.response)
+            with st.expander("Matched FAQ"):
+                st.write(result.faq_entry.get("title", ""))
+                st.caption(result.faq_entry.get("body", ""))
+            if result.honeyhive_score:
+                st.caption(
+                    "HoneyHive (mock) — tone: {tone:.2f}, helpfulness: {helpfulness:.2f}. {notes}".format(
+                        tone=result.honeyhive_score.tone,
+                        helpfulness=result.honeyhive_score.helpfulness,
+                        notes=result.honeyhive_score.notes,
+                    )
+                )
+            st.markdown("---")
+
+st.markdown("---")
+st.markdown(
+    "Need to automate further? Export the Airia pipeline YAML from the repo and upload to Airia to orchestrate the same flow."
+)

--- a/bright_data.py
+++ b/bright_data.py
@@ -1,0 +1,129 @@
+"""Utility functions to talk to the Bright Data Web Scraper API."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import List, Dict, Optional
+
+try:
+    import requests
+except Exception:  # pragma: no cover - requests not critical for stub
+    requests = None  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_reviews_from_bright_data(
+    app_id: str,
+    store: str = "google",
+    max_reviews: int = 5,
+    api_token: Optional[str] = None,
+) -> List[Dict[str, str]]:
+    """Fetch reviews for an application via Bright Data.
+
+    Parameters
+    ----------
+    app_id:
+        Identifier of the target application. Examples include the bundle ID
+        for iOS (``com.example.app``) or the package name for Google Play.
+    store:
+        ``"google"`` for Google Play or ``"apple"`` for the App Store.
+    max_reviews:
+        Maximum number of reviews to return.
+    api_token:
+        Optional Bright Data API token. Defaults to ``BRIGHT_DATA_API_TOKEN``
+        environment variable.
+
+    Notes
+    -----
+    If no API token is supplied the function falls back to a deterministic
+    stub payload so that the rest of the demo can run without external
+    dependencies. The real API integration can be enabled by simply providing
+    a valid token.
+    """
+
+    token = api_token or os.getenv("BRIGHT_DATA_API_TOKEN")
+    # Bright Data configuration for documentation purposes. Leaving the
+    # request blueprint in place makes it easy to plug in real credentials.
+    if token and requests is not None:
+        endpoint = "https://api.brightdata.com/datasets/v3/trigger"  # Web Scraper API
+        # Bright Data requires a pre-configured dataset id with the scraping
+        # recipe. For hackathon demos we keep this configurable.
+        dataset_id = os.getenv("BRIGHT_DATA_DATASET_ID", "demo_app_reviews")
+        payload = {
+            "dataset_id": dataset_id,
+            "source": "google_play" if store == "google" else "app_store",
+            "query_params": {"app_id": app_id},
+            "limit": max_reviews,
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": token,
+        }
+        try:
+            response = requests.post(endpoint, headers=headers, data=json.dumps(payload), timeout=30)
+            response.raise_for_status()
+            data = response.json()
+            items = data.get("items", [])
+            reviews: List[Dict[str, str]] = []
+            for item in items[:max_reviews]:
+                reviews.append(
+                    {
+                        "id": str(item.get("id")),
+                        "author": item.get("user_name", "Anonymous"),
+                        "rating": item.get("rating", ""),
+                        "text": item.get("content", ""),
+                        "date": item.get("date", ""),
+                        "store": store,
+                    }
+                )
+            if reviews:
+                return reviews
+        except Exception as exc:  # pragma: no cover - we want resilience in demo
+            logger.warning("Bright Data API request failed, falling back to stub: %s", exc)
+
+    # Stubbed data path.
+    now = datetime.utcnow()
+    sample_reviews = [
+        {
+            "id": f"stub-{idx}",
+            "author": name,
+            "rating": rating,
+            "text": text,
+            "date": (now - timedelta(days=idx)).strftime("%Y-%m-%d"),
+            "store": store,
+        }
+        for idx, (name, rating, text) in enumerate(
+            [
+                (
+                    "Jamie",
+                    "2",
+                    "The app keeps crashing whenever I try to upload a photo. Please fix this soon!",
+                ),
+                (
+                    "Lee",
+                    "4",
+                    "Overall great experience but it takes forever to load the dashboard on older phones.",
+                ),
+                (
+                    "Morgan",
+                    "5",
+                    "Love the latest update—thanks for listening to user feedback!",
+                ),
+                (
+                    "Riley",
+                    "3",
+                    "Could you add a dark mode? It's hard to use at night without it.",
+                ),
+            ]
+        )
+    ]
+
+    logger.info("Returning %s stub reviews", len(sample_reviews))
+    return sample_reviews[:max_reviews]
+
+
+__all__ = ["fetch_reviews_from_bright_data"]

--- a/data/faq.json
+++ b/data/faq.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "faq_crash",
+    "category": "bug",
+    "title": "App crashes or won't open",
+    "body": "Thanks for letting us know about the crash. Our team is already investigating. If possible, please share your device model and OS version so we can reproduce the issue quickly."
+  },
+  {
+    "id": "faq_performance",
+    "category": "complaint",
+    "title": "Slow performance or lag",
+    "body": "We appreciate the heads-up about the slow down. Clearing cached data and ensuring the latest update is installed usually helps. We're monitoring performance closely and have optimizations scheduled for the next release."
+  },
+  {
+    "id": "faq_feature",
+    "category": "feature request",
+    "title": "Requesting a new feature",
+    "body": "We love hearing new ideas! The product team reviews every request. While we can't promise an ETA, your feedback directly shapes the roadmap."
+  },
+  {
+    "id": "faq_praise",
+    "category": "praise",
+    "title": "Positive feedback",
+    "body": "Thank you for sharing the love! We'll pass your kind words to the team—it means a lot and keeps us motivated to keep building great experiences."
+  },
+  {
+    "id": "faq_payment",
+    "category": "complaint",
+    "title": "Billing or subscription issue",
+    "body": "I'm sorry for the billing hiccup. Please double-check that your payment method is current. If you're still seeing unexpected charges, contact support via the in-app Help Center so we can resolve it right away."
+  },
+  {
+    "id": "faq_account",
+    "category": "bug",
+    "title": "Cannot log in",
+    "body": "We're sorry you're locked out. Resetting your password from the login screen usually does the trick. If not, email support with your registered email so we can take a closer look."
+  }
+]

--- a/faq_loader.py
+++ b/faq_loader.py
@@ -1,0 +1,21 @@
+"""Helpers for loading the FAQ knowledge base."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_FAQ_PATH = Path(__file__).resolve().parent / "data" / "faq.json"
+
+
+def load_faq_entries(path: Optional[str] = None) -> List[Dict[str, str]]:
+    """Load the FAQ entries from disk."""
+    faq_path = Path(path) if path else DEFAULT_FAQ_PATH
+    if not faq_path.exists():
+        raise FileNotFoundError(f"FAQ file not found at {faq_path}")
+    with faq_path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return data
+
+
+__all__ = ["load_faq_entries", "DEFAULT_FAQ_PATH"]

--- a/honeyhive.py
+++ b/honeyhive.py
@@ -1,0 +1,36 @@
+"""Mock HoneyHive evaluator used for hackathon demos."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HoneyHiveScore:
+    tone: float
+    helpfulness: float
+    notes: str
+
+
+class HoneyHiveEvaluator:
+    """Return deterministic scores for tone and helpfulness."""
+
+    def score(self, review_text: str, response_text: str) -> HoneyHiveScore:
+        review_lower = review_text.lower()
+        response_lower = response_text.lower()
+        tone = 0.6
+        helpfulness = 0.6
+        if any(word in response_lower for word in ["thank", "sorry", "appreciate", "love"]):
+            tone += 0.2
+        if any(word in response_lower for word in ["step", "plan", "team", "update", "investigating"]):
+            helpfulness += 0.2
+        if "!" in response_text:
+            tone += 0.05
+        if "?" in review_text:
+            helpfulness += 0.05
+        tone = min(tone, 1.0)
+        helpfulness = min(helpfulness, 1.0)
+        notes = "Mock HoneyHive evaluation (replace with real API call when available)."
+        return HoneyHiveScore(tone=tone, helpfulness=helpfulness, notes=notes)
+
+
+__all__ = ["HoneyHiveEvaluator", "HoneyHiveScore"]

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,100 @@
+"""Airia orchestration pipeline for responding to reviews."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from honeyhive import HoneyHiveEvaluator, HoneyHiveScore
+from retrieval import FAQRetriever
+
+
+CATEGORY_KEYWORDS = {
+    "bug": ["crash", "bug", "error", "freeze", "won't", "cant", "can't", "issue"],
+    "feature request": ["feature", "wish", "add", "could you", "dark mode", "missing"],
+    "praise": ["love", "great", "amazing", "awesome", "thank", "favorite"],
+    "complaint": ["slow", "lag", "bad", "frustrated", "billing", "charge", "annoying", "unhappy"],
+}
+DEFAULT_CATEGORY = "complaint"
+
+
+@dataclass
+class ReviewResult:
+    review: Dict[str, str]
+    category: str
+    faq_entry: Dict[str, str]
+    response: str
+    honeyhive_score: Optional[HoneyHiveScore] = None
+
+
+def classify_review(review_text: str) -> str:
+    lowered = review_text.lower()
+    best_category = DEFAULT_CATEGORY
+    best_score = 0
+    for category, keywords in CATEGORY_KEYWORDS.items():
+        score = sum(1 for keyword in keywords if keyword in lowered)
+        if score > best_score:
+            best_score = score
+            best_category = category
+    return best_category
+
+
+def generate_response(review: Dict[str, str], category: str, faq_entry: Dict[str, str]) -> str:
+    author = review.get("author") or "there"
+    rating = review.get("rating")
+    review_text = review.get("text", "")
+    base_intro = {
+        "bug": "I'm sorry you're running into trouble",
+        "feature request": "Thank you for the thoughtful idea",
+        "praise": "We're thrilled you're enjoying the app",
+        "complaint": "Thanks for sharing your experience",
+    }.get(category, "Thanks for reaching out")
+
+    rating_snippet = f" and for leaving a {rating}-star rating" if rating else ""
+    faq_answer = faq_entry.get("body", "")
+    category_line = {
+        "bug": "Our engineers are actively looking into issues like the one you described.",
+        "feature request": "I've shared your request with the product team so it can influence the roadmap.",
+        "praise": "Feedback like yours keeps us motivated to keep building.",
+        "complaint": "We're keeping a close eye on similar reports so we can improve right away.",
+    }.get(category, "We're on it.")
+
+    response = (
+        f"Hi {author}, {base_intro}{rating_snippet}. "
+        f"I read your note (\"{review_text}\") and want you to know we're listening. "
+        f"{faq_answer} {category_line}"
+        " If you have more details to share, just reply to this review or contact support and we'll jump in."
+        " Thanks again for helping us build a better app!"
+    )
+    return response.strip()
+
+
+class AiriaPipeline:
+    """Simple Airia-style orchestrator with explicit steps."""
+
+    def __init__(self, enable_honeyhive: bool = True) -> None:
+        self.retriever = FAQRetriever()
+        self.honeyhive = HoneyHiveEvaluator() if enable_honeyhive else None
+
+    def run(self, review: Dict[str, str]) -> ReviewResult:
+        review_text = review.get("text", "")
+        category = classify_review(review_text)
+        faq_entry = self.retriever.retrieve(review_text, category=category)
+        response = generate_response(review, category, faq_entry)
+        honeyhive_score = None
+        if self.honeyhive:
+            honeyhive_score = self.honeyhive.score(review_text, response)
+        return ReviewResult(
+            review=review,
+            category=category,
+            faq_entry=faq_entry,
+            response=response,
+            honeyhive_score=honeyhive_score,
+        )
+
+
+__all__ = [
+    "AiriaPipeline",
+    "ReviewResult",
+    "classify_review",
+    "generate_response",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit>=1.25
+llama-index>=0.9.30
+requests>=2.31

--- a/retrieval.py
+++ b/retrieval.py
@@ -1,0 +1,95 @@
+"""Retrieval layer backed by LlamaIndex with a keyword fallback."""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+from faq_loader import load_faq_entries
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    from llama_index.core import Document, VectorStoreIndex
+    from llama_index.core import Settings  # type: ignore[attr-defined]
+    from llama_index.embeddings.mock import MockEmbedding
+
+    try:  # Some versions expose Settings under llama_index
+        Settings
+    except NameError:  # pragma: no cover - defensive
+        from llama_index import Settings  # type: ignore
+
+    Settings.embed_model = MockEmbedding()
+    LLAMA_AVAILABLE = True
+except Exception:  # pragma: no cover - when llama_index not installed
+    Document = None  # type: ignore
+    VectorStoreIndex = None  # type: ignore
+    Settings = None  # type: ignore
+    LLAMA_AVAILABLE = False
+
+
+class FAQRetriever:
+    """Thin wrapper around LlamaIndex to serve FAQ snippets."""
+
+    def __init__(
+        self,
+        faq_entries: Optional[List[Dict[str, str]]] = None,
+        use_llamaindex: bool = True,
+    ) -> None:
+        self.faq_entries = faq_entries or load_faq_entries()
+        self._retriever = None
+        self.use_llamaindex = use_llamaindex and LLAMA_AVAILABLE
+        if self.use_llamaindex:
+            try:
+                documents = [
+                    Document(
+                        text=(
+                            f"Category: {entry['category']}\n"
+                            f"Title: {entry['title']}\n"
+                            f"Answer: {entry['body']}"
+                        ),
+                        metadata=entry,
+                    )
+                    for entry in self.faq_entries
+                ]
+                index = VectorStoreIndex.from_documents(documents)
+                self._retriever = index.as_retriever(similarity_top_k=1)
+                logger.info("Initialized LlamaIndex retriever with %s FAQ entries", len(documents))
+            except Exception as exc:  # pragma: no cover - best effort fallback
+                logger.warning("Failed to initialize LlamaIndex (%s). Falling back to keyword search.", exc)
+                self.use_llamaindex = False
+        if not self.use_llamaindex:
+            logger.info("Using keyword fallback retriever.")
+
+    def retrieve(self, query: str, category: Optional[str] = None) -> Dict[str, str]:
+        """Return the FAQ entry that best matches the query."""
+        if self.use_llamaindex and self._retriever is not None:
+            nodes = self._retriever.retrieve(query)
+            if nodes:
+                metadata = dict(nodes[0].metadata)
+                # Ensure we always return the full FAQ entry.
+                return metadata
+
+        # Simple keyword fallback.
+        lowered_query = query.lower()
+        best_score = -1
+        best_entry: Dict[str, str] = self.faq_entries[0]
+        for entry in self.faq_entries:
+            score = 0
+            if category and entry.get("category") == category:
+                score += 5
+            title = entry.get("title", "").lower()
+            body = entry.get("body", "").lower()
+            for token in ["crash", "bug", "slow", "lag", "feature", "request", "love", "thanks", "billing", "charge", "login", "password", "mode", "dark"]:
+                if token in lowered_query and token in (title + body):
+                    score += 2
+            if any(word in lowered_query for word in title.split()):
+                score += 1
+            if any(word in lowered_query for word in body.split()):
+                score += 0.5
+            if score > best_score:
+                best_score = score
+                best_entry = entry
+        return best_entry
+
+
+__all__ = ["FAQRetriever", "LLAMA_AVAILABLE"]


### PR DESCRIPTION
## Summary
- add a Streamlit dashboard that fetches Bright Data reviews, runs them through the Airia pipeline, and renders responses
- wire up Bright Data fetcher, FAQ loader, LlamaIndex-based retriever with keyword fallback, and HoneyHive mock scoring
- document the workflow, dependencies, and supply an Airia pipeline YAML plus FAQ knowledge base

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cdca461514832baf47b88e8dfff10f